### PR TITLE
Fix candidate selection for multi-character input

### DIFF
--- a/Etem_26Keys.schema.yaml
+++ b/Etem_26Keys.schema.yaml
@@ -61,7 +61,7 @@ speller:
     delimiter: "'"
     max_code_length: 4
     auto_select: false
-    auto_select_unique_candidate: true
+    auto_select_unique_candidate: false
     use_space: true
     algebra:
         - derive/^([a-z]{4}).+/$1/
@@ -69,7 +69,7 @@ speller:
 translator:
     dictionary: Etem26keys
     enable_user_dict: true
-    enable_sentence: false
+    enable_sentence: true
     enable_completion: true
 
 punctuator:

--- a/Mobile (Fcitx5)/Etem_26Keys.schema.yaml
+++ b/Mobile (Fcitx5)/Etem_26Keys.schema.yaml
@@ -61,7 +61,7 @@ speller:
     delimiter: "'"
     max_code_length: 4
     auto_select: false
-    auto_select_unique_candidate: true
+    auto_select_unique_candidate: false
     use_space: true
     algebra:
         - derive/^([a-z]{4}).+/$1/
@@ -69,7 +69,7 @@ speller:
 translator:
     dictionary: Etem26keys
     enable_user_dict: true
-    enable_sentence: false
+    enable_sentence: true
     enable_completion: true
 
 punctuator:


### PR DESCRIPTION
## Summary
- allow composing multiple characters before committing by disabling automatic selection of unique candidates
- enable sentence output so multi-character codes stay in the preedit area until confirmed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690ad47c3aa0832da8201c1fd7d836d2