### PR TITLE
Refine confirmation flow and punctuation output

### DIFF
--- a/Etem26keys.dict.yaml
+++ b/Etem26keys.dict.yaml
@@ -12883,6 +12883,7 @@ columns:
 楱	wpk	2
 腠	wpk	1
 測	wrk	14
+測試	wrkck	100
 策	wrk	13
 冊	wrk	12
 側	wrk	11

--- a/Etem_26Keys.schema.yaml
+++ b/Etem_26Keys.schema.yaml
@@ -61,26 +61,26 @@ speller:
     delimiter: "'"
     max_code_length: 4
     auto_select: false
-    auto_select_unique_candidate: true
-    use_space: true
+    auto_select_unique_candidate: false
+    use_space: false
     algebra:
         - derive/^([a-z]{4}).+/$1/
 
 translator:
     dictionary: Etem26keys
     enable_user_dict: true
-    enable_sentence: false
-    enable_completion: true
+    enable_sentence: true
+    enable_completion: false
 
 punctuator:
     import_preset: symbols
     half_shape:
-        ",": "，"
-        ".": "。"
-        ";": "；"
-        ":": "："
-        '"': ["「", "」"]
-        "'": ["『", "』"]
+        ",": ","
+        ".": "."
+        ";": ";"
+        ":": ":"
+        '"': '"'
+        "'": "'"
 
 key_binder:
     import_preset: default

--- a/Mobile (Fcitx5)/Etem_26Keys.schema.yaml
+++ b/Mobile (Fcitx5)/Etem_26Keys.schema.yaml
@@ -61,26 +61,26 @@ speller:
     delimiter: "'"
     max_code_length: 4
     auto_select: false
-    auto_select_unique_candidate: true
-    use_space: true
+    auto_select_unique_candidate: false
+    use_space: false
     algebra:
         - derive/^([a-z]{4}).+/$1/
 
 translator:
     dictionary: Etem26keys
     enable_user_dict: true
-    enable_sentence: false
-    enable_completion: true
+    enable_sentence: true
+    enable_completion: false
 
 punctuator:
     import_preset: symbols
     half_shape:
-        ",": "，"
-        ".": "。"
-        ";": "；"
-        ":": "："
-        '"': ["「", "」"]
-        "'": ["『", "』"]
+        ",": ","
+        ".": "."
+        ";": ";"
+        ":": ":"
+        '"': '"'
+        "'": "'"
 
 key_binder:
     import_preset: default


### PR DESCRIPTION
## Summary
- require pressing Enter to commit by disabling space selection
- drop completion-based candidates to avoid incorrect associations and stray symbols
- normalize punctuation to half-width characters and add a high-weight entry for "測試"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690ad47c3aa0832da8201c1fd7d836d2